### PR TITLE
demo: unamage `prd` because why not?

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,21 +10,22 @@
     - "name": "check all jobs for approval"
       "uses": "re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe"
       "with":
-        "allowed-skips": "call-workflows"
+        "allowed-skips": "generate-matrix"
         "jobs": "${{ toJSON(needs) }}"
   "call-workflows":
-    "if": "${{ needs.generate-matrix.outputs.matrix != '' }}"
-    "needs":
-    - "generate-matrix"
+    "if": true
+    "needs": []
     "secrets": "inherit"
     "strategy":
       "matrix":
-        "environments": "${{ fromJSON(needs.generate-matrix.outputs.matrix) }}"
+        "environments":
+        - "dev"
+        - "staging"
     "uses": "./.github/workflows/called.yaml"
     "with":
       "environment": "${{ matrix.environments }}"
   "generate-matrix":
-    "if": true
+    "if": false
     "outputs":
       "matrix": "${{ steps.generate.outputs.matrix }}"
     "runs-on":
@@ -37,7 +38,7 @@
     - "id": "generate"
       "name": "generate matrix"
       "run": |
-        output="$(for i in dev staging prod ; do [[ -z $(git diff --name-only origin/main...HEAD | grep -E "stacks/${i}") ]] || echo $i ; done)"
+        output="$(for i in dev staging ; do [[ -z $(git diff --name-only origin/main...HEAD | grep -E "stacks/${i}") ]] || echo $i ; done)"
         [ -z "$output" ] || echo "matrix=[\""${output//[ ]/\", \"}"\"]" >> "$GITHUB_OUTPUT"
 "name": "main"
 "on":

--- a/globals.tm.hcl
+++ b/globals.tm.hcl
@@ -11,10 +11,10 @@ globals "workflows" {
 
 globals "repository" {
   # which environments to manage
-  environments = ["dev", "staging", "prod"]
+  environments = ["dev", "staging"]
   # run workflows on all environments regardless of change
   # reducing the number of jobs based on changes optimises github actions runtime
-  always_run = false
+  always_run = true
   # toggle chaotic good example for workflow generation (json > yaml)
   chaotic_good = false
 }


### PR DESCRIPTION
this pull requests demonstrates what happens if we don't want to manage our `prod` environment. `always_run` is `true` for showcasing the others are still managed